### PR TITLE
Add Semihosting

### DIFF
--- a/top.core_desc
+++ b/top.core_desc
@@ -7,7 +7,7 @@ import "rv_base/RVF.core_desc"
 import "tum_mod.core_desc"
 
 
-Core RV32IMACFD provides RV32I, RV32IC, RV32M, RV32F, RV32FC, RV32D, RV32DC, Zifencei, tum_csr, tum_ret, tum_rva {
+Core RV32IMACFD provides RV32I, RV32IC, RV32M, RV32F, RV32FC, RV32D, RV32DC, Zifencei, tum_csr, tum_ret, tum_rva, tum_semihosting {
     architectural_state {
         CSR[0x000] = 0x0000000B; // ustatus
         CSR[RV_CSR_SSTATUS] = 0x0000000B; // sstatus
@@ -23,7 +23,7 @@ Core RV32IMACFD provides RV32I, RV32IC, RV32M, RV32F, RV32FC, RV32D, RV32DC, Zif
     }
 }
 
-Core RV64IM provides RV64I, RV32M, tum_csr, tum_ret {
+Core RV64IM provides RV64I, RV32M, tum_csr, tum_ret, tum_semihosting {
     architectural_state {
         CSR[0x000] = 0x0000000B; // ustatus
         CSR[RV_CSR_SSTATUS] = 0x0000000B; // sstatus

--- a/tum_mod.core_desc
+++ b/tum_mod.core_desc
@@ -237,3 +237,36 @@ InstructionSet tum_rva extends RV32A {
         }
     }
 }
+
+
+InstructionSet tum_semihosting extends RV32I {
+    instructions {
+        EBREAK [[no_cont]] [[cond]] {
+            encoding: 0b000000000001 :: 5'b00000 :: 3'b000 :: 5'b00000 :: 7'b1110011;
+            behavior: {
+                if (etiss_semihost_enabled()) {
+                    unsigned<32> pre    = (unsigned<32>)MEM[PC - 4];
+                    unsigned<32> ebreak = (unsigned<32>)MEM[PC + 0];
+                    unsigned<32> post   = (unsigned<32>)MEM[PC + 4];
+                    if ( pre    == 0x01f01013 // slli x0, x0, 0x1f   Entry NOP
+                      && ebreak == 0x00100073 // ebreak              Break to debugger
+                      && post   == 0x40705013 // srai x0, x0, 7      NOP encoding the semihosting call number 7
+                    ) {
+                    unsigned<XLEN> operation = X[10];
+                    unsigned<XLEN> parameter = X[11];
+                    X[10] = (signed<XLEN>)etiss_semihost(XLEN, operation, parameter);
+                    } else {
+                        raise(0, RV_CAUSE_BREAKPOINT);
+                    }
+                } else {
+                    raise(0, RV_CAUSE_BREAKPOINT);
+                }
+            }
+        }
+    }
+    
+    functions {
+        extern unsigned<8> etiss_semihost_enabled();
+        extern signed<64> etiss_semihost(unsigned<32> XLEN, unsigned<64> operation, unsigned<64> parameter) [[etiss_needs_arch]];
+    }
+}


### PR DESCRIPTION
This pull request adds semihosting by overriding the behavior of the `EBREAK` instruction.
To work in ETISS it needs the semihosting JitLib.